### PR TITLE
unite 絞込み時の candidate のシンタックスハイライト

### DIFF
--- a/autoload/unite/sources/quickfix.vim
+++ b/autoload/unite/sources/quickfix.vim
@@ -4,7 +4,6 @@ function! unite#sources#quickfix#define()
 	return s:source
 endfunction
 
-
 function! unite#sources#quickfix#word_formatter(val)
 	let fname = a:val.bufnr == 0 ? "" : bufname(a:val.bufnr)
 	let line  = fname == "" ? "" : a:val.lnum
@@ -35,6 +34,8 @@ let g:Unite_quickfix_yank_text_formatter =
 let s:source = {
 \	"name" : "quickfix",
 \	"description" : "output quickfix",
+\	"syntax" : "uniteSource__QuickFix",
+\	"hooks" : {},
 \}
 
 function! s:qflist_to_unite(val)
@@ -72,3 +73,18 @@ function! s:source.gather_candidates(args, context)
 	endif
 endfunction
 
+function! s:hl_candidates()
+	syntax match uniteSource__QuickFix_Header /[^|]*|\d*|/
+\		contained containedin=uniteSource__QuickFix
+\		contains=uniteSource__QuickFix_File,uniteSource__QuickFix_LineNr
+	syntax match uniteSource__QuickFix_File /[^|]*/
+\		contained containedin=uniteSource__QuickFix_Header nextgroup=uniteSource__QuickFix_LineNr
+	syntax match uniteSource__QuickFix_LineNr /|\d*|/hs=s+1,he=e-1
+\		contained containedin=uniteSource__QuickFix_Header
+	highlight default link uniteSource__QuickFix_File Directory
+	highlight default link uniteSource__QuickFix_LineNr LineNr
+endfunction
+
+function! s:source.hooks.on_syntax(args, context)
+	call s:hl_candidates()
+endfunction


### PR DESCRIPTION
こんばんは．
unite-quickfix 便利に使わせていただいているのですが，quickfix に比べて唯一劣っていると感じるのがハイライトでした．
せっかく word_formatter で共通したフォーマットを提供しているので，ファイル名と行数の部分にハイライトをかけてみました．ハイライトの色は quickfix と合わせてあります．

solarized でハイライトすると unite バッファはこんな感じになります．
![alt text](http://d3j5vwomefv46c.cloudfront.net/photos/full/661775331.jpg?key=902242&Expires=1348512867&Key-Pair-Id=APKAIYVGSUJFNRFZBBTA&Signature=qFq4AAtIjjfYA0~c7uP42dDQ7KLVP-OwY8T3kYlcr2hFFRpjnFFZ88mm4zp1aj0XKp3UA1GEB0kfD~fVRTxO2GFRaJ1FbZPmFPF~OW6gjvDrhMZE1aX4rllPlNo~4LZDB0qDuvGmHd86uc3uPGUaxVjJ~GPexxhiOn20pQR9kW4_)
